### PR TITLE
fixing lfqGen when K is provided

### DIFF
--- a/R/lfqGen.R
+++ b/R/lfqGen.R
@@ -56,7 +56,7 @@
 #' 
 lfqGen <- function(
 tincr = 1/12,
-K.mu = 0.5, K.cv = 0.1,
+K.mu = NaN, K.cv = 0.1,
 Linf.mu = 80, Linf.cv = 0.1,
 phiprime.mu = 3.5,
 ts = 0, C = 0.85,
@@ -73,6 +73,9 @@ fished_t = seq(0,5,tincr),
 lfqFrac = 1,
 progressBar = TRUE
 ){
+
+# estimate phiprime if K.mu is given
+if(!is.nan(K.mu)) phiprime.mu <- log10(K.mu) + 2 * log10(Linf.mu)
 
 # times
 timeseq = seq(from=timemin, to=timemax, by=tincr)


### PR DESCRIPTION
The input value of K is not used, instead the default value of `phiprime.mu` is used to calculate K values for individuals. So either the user has to calculate and enter `phi prime.mu` by himself and K is deleted from the input parameters or another option would be: `phi prime.mu` is calculated within the function if K is provided and by default K is `NaN`. I implemented the latter.
