### PR TITLE
change default values of lfqGen

### DIFF
--- a/R/lfqGen.R
+++ b/R/lfqGen.R
@@ -78,9 +78,9 @@ repro_wt = c(0,0,0,1,0,0,0,0,0,0,0,0),
 M = 0.7, harvest_rate = M, 
 L50 = 0.25*Linf.mu, wqs = L50*0.2,
 bin.size = 1,
-timemin = 0, timemax = 5, timemin.date = as.Date("1980-01-01"),
+timemin = 0, timemax = 20, timemin.date = as.Date("1980-01-01"),
 N0 = 10000,
-fished_t = seq(0,5,tincr),
+fished_t = seq(17,19,tincr),
 lfqFrac = 1,
 progressBar = TRUE
 ){


### PR DESCRIPTION
I suggest to change the default values of the maximum simulation time and the fishing time. The previous values (simulation time of 5 years, fishing during all 5 years) samples the population during a time where equilibrium is not yet reached, and thus influences any analysis with produced  dataset. The new values sample the population once it reached equilibrium and allow the estimation of stable population characteristics. Computing speed difference is not too large. And function makes more sense with its default parameter values.