### PR TITLE
error in dt_growth_soVB affecting stock simulation

### DIFF
--- a/R/dt_growth_soVB.R
+++ b/R/dt_growth_soVB.R
@@ -53,8 +53,8 @@ dt_growth_soVB <- function(Linf, K, ts, C, L1, t1, t2){
   dt <- (Linf - L1) *
   {1 - exp(-(
     K*(t2-t1)
-    - (((C*K)/(2*pi))*sin(2*pi*(t1-ts)))
-    + (((C*K)/(2*pi))*sin(2*pi*(t2-ts)))
+    + (((C*K)/(2*pi))*sin(2*pi*(t1-ts)))
+    - (((C*K)/(2*pi))*sin(2*pi*(t2-ts)))
   ))}
   L2 <- L1 + dt
   L2


### PR DESCRIPTION
While seasonalised VBGF has been corrected in growth_soVBGF, it has not been corrected in dt_growth_soVB. It should say + S(t) - S(t0).